### PR TITLE
use systemd for start/ stop via browser

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -140,8 +140,7 @@ if ($startstop == 'start' || $startstop == 'stop') {
 			}
 			file_put_contents($myFile, $stringData, FILE_APPEND);
 		} else {
-			$command = 'sudo systemctl start 123solar.service';
-			$PID     = exec($command);
+			$command = exec("sudo systemctl stop 123solar.service");
 		}
 		for ($i = 1; $i <= $NUMINV; $i++) {
 			if ($DEBUG) {

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -140,9 +140,8 @@ if ($startstop == 'start' || $startstop == 'stop') {
 			}
 			file_put_contents($myFile, $stringData, FILE_APPEND);
 		} else {
-			$command = 'php ../scripts/123solar.php' . ' > /dev/null 2>&1 & echo $!;';
+			$command = 'sudo systemctl start 123solar.service';
 			$PID     = exec($command);
-			file_put_contents('../scripts/123solar.pid', $PID);
 		}
 		for ($i = 1; $i <= $NUMINV; $i++) {
 			if ($DEBUG) {
@@ -160,8 +159,7 @@ if ($startstop == 'start' || $startstop == 'stop') {
 	}
 	if ($startstop == 'stop') {
 		if (!is_null($PID)) {
-			$command = exec("kill $PID > /dev/null 2>&1 &");
-			unlink('../scripts/123solar.pid');
+			$command = exec("sudo systemctl stop 123solar.service");
 			if ($DEBUG) {
 				$stringData = "#* $now\tStopping 123Solar debug ($PID)\n\n";
 				$myFile     = '../data/123solar.err';

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -140,7 +140,7 @@ if ($startstop == 'start' || $startstop == 'stop') {
 			}
 			file_put_contents($myFile, $stringData, FILE_APPEND);
 		} else {
-			$command = exec("sudo systemctl stop 123solar.service");
+			$command = exec("sudo systemctl start 123solar.service");
 		}
 		for ($i = 1; $i <= $NUMINV; $i++) {
 			if ($DEBUG) {

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -140,7 +140,15 @@ if ($startstop == 'start' || $startstop == 'stop') {
 			}
 			file_put_contents($myFile, $stringData, FILE_APPEND);
 		} else {
-			$command = exec("sudo systemctl start 123solar.service");
+			$output=null;
+			exec("sudo systemctl is-enabled 123solar.service",$output);
+			if (is_dir('/run/systemd/system') && ($output[0] == "enabled")) {
+				$command = exec("sudo systemctl start 123solar.service");
+			} else {
+				$command = 'php ../scripts/123solar.php' . ' > /dev/null 2>&1 & echo $!;';
+				$PID     = exec($command);
+				file_put_contents('../scripts/123solar.pid', $PID);
+			}
 		}
 		for ($i = 1; $i <= $NUMINV; $i++) {
 			if ($DEBUG) {
@@ -158,7 +166,14 @@ if ($startstop == 'start' || $startstop == 'stop') {
 	}
 	if ($startstop == 'stop') {
 		if (!is_null($PID)) {
-			$command = exec("sudo systemctl stop 123solar.service");
+			$output=null;
+			exec("sudo systemctl is-enabled 123solar.service",$output);
+			if (is_dir('/run/systemd/system') && ($output[0] == "enabled")) {
+				$command = exec("sudo systemctl stop 123solar.service");
+			} else {
+				$command = exec("kill $PID > /dev/null 2>&1 &");
+				unlink('../scripts/123solar.pid');
+			}
 			if ($DEBUG) {
 				$stringData = "#* $now\tStopping 123Solar debug ($PID)\n\n";
 				$myFile     = '../data/123solar.err';


### PR DESCRIPTION
this **only** for non debug mode, I never used it.

create a sudoers file like:
`# /etc/sudoers.d/www-data`
`www-data ALL=(root) NOPASSWD: /usr/bin/systemctl restart 123solar.service`
`www-data ALL=(root) NOPASSWD: /usr/bin/systemctl stop 123solar.service`
`www-data ALL=(root) NOPASSWD: /usr/bin/systemctl start 123solar.service`
