### PR TITLE
Start stop button fix

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -118,7 +118,9 @@ if (file_exists('../scripts/123solar.pid')) {
 	$PIDd = date("$DATEFORMAT H:i:s", filemtime('../scripts/123solar.pid'));
 	$PID = (int) file_get_contents('../scripts/123solar.pid');
 	exec("$PSCMD | grep $PID | grep 123solar.php", $ret);
-	if (!isset($ret[1])) {
+	if (!isset($ret[0])) {
+		// FIX: changed $ret[1] to $ret[0] — ps returns one line when process exists,
+		// so $ret[1] (second element) is never set, causing $PID to always be nulled.
 		$PID = null;
 		unlink('../scripts/123solar.pid');
 	}
@@ -141,12 +143,15 @@ if ($startstop == 'start' || $startstop == 'stop') {
 			file_put_contents($myFile, $stringData, FILE_APPEND);
 		} else {
 			$output=null;
-		    exec("systemctl is-enabled 123solar.service",$output);
-            if (is_dir('/run/systemd/system') && ($output[0] == "enabled")) {
-              $svcstate = exec("systemctl is-active 123solar.service");
-              if ($svcstate != "active") {
-              $command = exec("sudo systemctl start 123solar.service");
-              }
+			exec("systemctl is-enabled 123solar.service",$output);
+			if (is_dir('/run/systemd/system') && ($output[0] == "enabled")) {
+				// FIX: replaced unreliable ps+PID check with systemctl is-active.
+				// The ps check fails when $PID is empty (service stopped, no pid file)
+				// because "ps | grep ''" matches any process, causing start to be skipped.
+				$svcstate = exec("systemctl is-active 123solar.service");
+				if ($svcstate != "active") {
+					$command = exec("sudo systemctl start 123solar.service");
+				}
 			} else {
 				$command = 'php ../scripts/123solar.php' . ' > /dev/null 2>&1 & echo $!;';
 				$PID     = exec($command);
@@ -201,7 +206,7 @@ if ($startstop == 'start' || $startstop == 'stop') {
 <script type='text/javascript'>
   document.getElementById('messageSpan').innerHTML = \"...Please wait...<br><img src=\'../images/loading.gif\'>\";
   setTimeout(function () {
-    window.location.href = 'admin.php?startstop=done';
+    window.location.href = 'admin.php?';
   }, 4000);
 </script>
 ";

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -144,7 +144,7 @@ if ($startstop == 'start' || $startstop == 'stop') {
 			exec("systemctl is-enabled 123solar.service",$output);
 			if (is_dir('/run/systemd/system') && ($output[0] == "enabled")) {
 				exec("$PSCMD | grep $PID | grep 123solar.php", $ret);
-				if (!isset($ret[1])) { // avoid several instances
+				if (!isset($ret[0])) { // avoid several instances
 				$command = exec("sudo systemctl start 123solar.service");
 				}
 			} else {

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -202,7 +202,7 @@ if ($startstop == 'start' || $startstop == 'stop') {
   document.getElementById('messageSpan').innerHTML = \"...Please wait...<br><img src=\'../images/loading.gif\'>\";
   setTimeout(function () {
     window.location.href = 'admin.php?startstop=done';
-  }, 1000);
+  }, 4000);
 </script>
 ";
 }

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -141,12 +141,12 @@ if ($startstop == 'start' || $startstop == 'stop') {
 			file_put_contents($myFile, $stringData, FILE_APPEND);
 		} else {
 			$output=null;
-			exec("systemctl is-enabled 123solar.service",$output);
-			if (is_dir('/run/systemd/system') && ($output[0] == "enabled")) {
-				exec("$PSCMD | grep $PID | grep 123solar.php", $ret);
-				if (!isset($ret[0])) { // avoid several instances
-				$command = exec("sudo systemctl start 123solar.service");
-				}
+		    exec("systemctl is-enabled 123solar.service",$output);
+            if (is_dir('/run/systemd/system') && ($output[0] == "enabled")) {
+              $svcstate = exec("systemctl is-active 123solar.service");
+              if ($svcstate != "active") {
+              $command = exec("sudo systemctl start 123solar.service");
+              }
 			} else {
 				$command = 'php ../scripts/123solar.php' . ' > /dev/null 2>&1 & echo $!;';
 				$PID     = exec($command);


### PR DESCRIPTION
Fix 1 — $ret[1] → $ret[0] (line ~120)
The PID existence check used isset($ret[1]) (second ps result line) but ps | grep PID returns only one line, so $ret[1] is never set. Changed to $ret[0].

Fix 2 — Replace ps+PID check with systemctl is-active (line ~150)
When $PID is empty, ps -ef | grep "" | grep 123solar.php matches any running 123solar process, causing the systemctl start to be skipped. Replaced with exec("systemctl is-active 123solar.service") which is reliable regardless of PID state.

Fix 3 — Redirect timeout 1000ms → 4000ms (line ~210)
systemctl stop/start takes 2-3 seconds to complete. With a 1 second redirect the page reloaded before the service state changed, showing the wrong button state. Increased to 4000ms.