### PR TITLE
Let a style add its own content to <head>

### DIFF
--- a/styles/default/Explanation.txt
+++ b/styles/default/Explanation.txt
@@ -11,6 +11,8 @@ The links to indexes are like this : <a href="index.php"><?php echo "$lgMINDEX";
 
 "yourheader" is used for your personnal need (eg: Google Analytics). The "globalheader" file shouldn't be touched.
 
+You may also add an optional "head.php" to your style folder. Whatever it prints goes inside <head>, just before your own style.css is loaded, so your style.css can still override it. It is the place for a viewport meta tag if your style is responsive, for web fonts, or for a CSS framework. Styles without that file work exactly as before.
+
 Well overhall, i guess it's more talking to take a look on the examples ;)
 
 Jean-Marc

--- a/styles/globalheader.php
+++ b/styles/globalheader.php
@@ -35,7 +35,15 @@ echo "
 <script type='text/javascript' src='$HCdd'></script>
 <script type='text/javascript' src='$HCexp'></script>
 <script type='text/javascript' src='$HCann'></script>
-<link rel='stylesheet' href='styles/$STYLE/css/style.css' type='text/css'>
+";
+// Optional per-style <head> additions: a viewport meta tag, web fonts, a
+// CSS framework... Included before the style's own sheet, so that the
+// style keeps the last word on anything loaded here. A style that does
+// not ship this file is unaffected.
+if (is_file("styles/$STYLE/head.php")) {
+	include "styles/$STYLE/head.php";
+}
+echo "<link rel='stylesheet' href='styles/$STYLE/css/style.css' type='text/css'>
 ";
 include 'styles/yourheader.php';
 echo '</head>';


### PR DESCRIPTION
A style currently gets two hooks, header.php and footer.php, and both start at <body>. There is no way for it to reach inside <head>: the only head hook is styles/yourheader.php, which is shared by every style and is included after the style sheet, so it cannot be used to load anything the style then wants to override.

Two things follow from that. A responsive style cannot ship the viewport meta tag it needs; m.php has one, but the regular pages have none, so they render at the default virtual width on phones whatever the style does. And a style that wants a web font or a CSS framework has to load it from yourheader.php, i.e. after its own style.css, where the framework wins every specificity tie against the style itself.

Include styles/<style>/head.php when it exists, just before the style sheet. Styles that do not ship the file render exactly as before.