### PR TITLE
updater: keep user protocols across an update

### DIFF
--- a/admin/updater.php
+++ b/admin/updater.php
@@ -193,6 +193,29 @@ if (!$error) {
     }
 }
 
+// Import user protocols
+// Anything under scripts/protocols/ that the new release does not ship is a
+// user protocol: it would otherwise be lost, and a missing protocol is not
+// reported anywhere, since including a file that no longer exists is only a
+// PHP warning. Derived from the extracted release instead of a hardcoded
+// list, so it needs no upkeep when protocols are added or removed.
+if (!$error) {
+	$stockproto = scandir("$SRVDIR/_INSTALL/123solar/scripts/protocols/");
+	$protodir   = scandir("$CURDIR/scripts/protocols/");
+	$cnt        = count($protodir);
+	for ($i = 0; $i < $cnt; $i++) {
+		if (in_array($protodir[$i], array('.', '..')) || in_array($protodir[$i], $stockproto)) {
+			continue;
+		}
+		if (!xcopy("$CURDIR/scripts/protocols/$protodir[$i]", "$SRVDIR/_INSTALL/123solar/scripts/protocols/$protodir[$i]", 0644)) {
+			$error = true;
+			$log .= "ERROR: Failed to import protocol $protodir[$i]<br>";
+		} else {
+			$log .= "OK: Imported user protocol $protodir[$i]<br>";
+		}
+	}
+}
+
 if (!$error) {
 	if (file_exists("$CURDIR/scripts/123solar.pid")) {
 		$pid     = (int) file_get_contents("$CURDIR/scripts/123solar.pid");


### PR DESCRIPTION
The updater re-imports data/, config/ and non-stock style folders from the old installation, but nothing under scripts/protocols/. A protocol added by the user is therefore deleted by the update, and the inverters that rely on it stop being read.

Nothing reports it. config_invt*.php still names the protocol, and including a file that no longer exists is only a PHP warning, so there is no "Communication error" and no entry in the events log: the affected inverters simply stop producing samples until someone notices and restores the files by hand.

Import back every entry of scripts/protocols/ that the new release does not ship. The list of stock protocols is read from the extracted release rather than hardcoded, so it needs no upkeep when a protocol is added or removed upstream; xcopy already handles a protocol split over a subdirectory.

A protocol dropped by a new release is kept rather than removed. That is the safe side of the trade: config_invt*.php refers to protocols by name, so silently removing one would leave the configuration pointing at nothing.