### PR TITLE
Remove deprecated utf8_encode() call in the csv syntax checker

### DIFF
--- a/admin/fsyntax.php
+++ b/admin/fsyntax.php
@@ -61,12 +61,17 @@ foreach ($iterator as $file) {
             $err = true;
             echo "<br><b>$path<b>: is corrupted<br>";
         } else {
-            $rows       = array();
             $row_number = 0;
             while ($csv_row = fgetcsv($csv, 0, ',')) {
                 $row_number++;
-                $encoded_row = array_map('utf8_encode', $csv_row);
-                if (count($encoded_row) != $cnt) {
+                // utf8_encode() used to run over $csv_row here before this
+                // count check, but array_map() never changes an array's
+                // length - it had no effect on the check below, and its
+                // result was not used anywhere else. Dropped rather than
+                // replaced: utf8_encode()/utf8_decode() are deprecated as
+                // of PHP 8.2, and there is nothing left for a replacement
+                // to do.
+                if (count($csv_row) != $cnt) {
                     $err = true;
                     echo "<br><b>$path</b>: length of row $row_number does not match the header length ($cnt)<br>";
                 }


### PR DESCRIPTION
utf8_encode()/utf8_decode() are deprecated since PHP 8.2. This debug tool (admin/fsyntax.php's csv check) called utf8_encode() on every row of the file under test - up to 400 times per check - so on 8.2+ with display_errors on, checking one csv file could print up to 400 deprecation notices from a page whose entire job is reporting problems with the file, not with itself.

Not replaced with a modern equivalent: array_map() never changes an array's length, so the encoded copy had no effect on the length check right below it, and was not used anywhere else in the function. There is nothing left for a replacement to do - the encoding step was already inert before this change, on any PHP version.

Measured before/after on three cases (regular row, short row, row with accented characters): identical pass/fail outcome in all three, and the deprecation notice is gone (checked with error_reporting=E_ALL, display_errors=1, the same wide-open configuration display_errors=1 represents in production).