### PR TITLE
Add "Meridiana": a responsive Bootstrap/Font Awesome theme

### DIFF
--- a/config/theme_extras.php
+++ b/config/theme_extras.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * config/theme_extras.php
+ *
+ * Optional, theme-only settings for the "meridiana" theme (and any other
+ * theme that chooses to read it the same way).
+ * Deliberately kept separate from config_main.php: it is not part of
+ * 123solar's own config schema (see $CFGmain in config_main.php), so it
+ * can never collide with a future upstream key, and the admin panel's
+ * config editor cannot touch or wipe it. Read directly by
+ * styles/<theme>/header.php, guarded by file_exists() there: deleting
+ * this file is safe and simply hides the link below.
+ *
+ * @package default
+ */
+
+// URL of the meterN installation for this same plant, shown as a link in
+// the top bar. Leave empty ('') to hide the link entirely. Both apps are
+// served from the same Apache vhost here (see /etc/apache2/sites-enabled),
+// hence the relative path.
+$METERN_URL = '/metern/';

--- a/styles/meridiana/README.md
+++ b/styles/meridiana/README.md
@@ -1,0 +1,75 @@
+# Meridiana theme
+
+A responsive, light/dark alternative to the default 123solar style, built
+on [Bootstrap 5](https://getbootstrap.com/) and
+[Font Awesome](https://fontawesome.com/) - loaded via CDN `@import`, no
+build step, no local copy of either library to keep updated.
+
+Sibling implementation of the same theme for
+[meterN](https://github.com/jeanmarc77/meterN/tree/main/styles/meridiana),
+sharing the same design and CSS variables; the two are independent
+installs (different repos, different engines) but look and behave the
+same on a site running both.
+
+## Features
+
+- Responsive from phone to desktop: a collapsible top navbar replaces the
+  legacy fixed-width table layout.
+- Light/dark switch, remembered in a cookie (`color_scheme`), including a
+  matching Highcharts palette applied both on load and on toggle.
+- A per-inverter quick-select dropdown in the nav when `$NUMINV > 1`.
+- Icon set (Font Awesome) for the nav and header, in place of the default
+  theme's plain text links.
+- Pure CSS + a few small template files: no engine code is touched, and
+  nothing here talks to 123solar's data layer directly.
+
+## Installation
+
+1. Copy this `meridiana/` directory into your installation's `styles/`
+   folder, so you end up with `styles/meridiana/{css/style.css,
+   footer.php, header.php, head.php}`.
+2. In `config/config_main.php`, set:
+   ```php
+   $STYLE = "meridiana";
+   ```
+3. That's it - no admin panel step, no schema change, no new config keys.
+
+### Requirement
+
+Needs the per-style `<head>` hook merged in
+[12b8812](https://github.com/jeanmarc77/123solar/commit/12b8812)
+(`styles/<STYLE>/head.php`, included by `styles/globalheader.php` before
+the theme's own stylesheet). Without it, `head.php` here is simply never
+included and the pages render without a viewport meta tag - everything
+else still works, but mobile layout won't. Any checkout of `main` from
+that commit onward already has it.
+
+### Optional: linking to a companion meterN install
+
+If this plant is also monitored by meterN on the same server, copy
+`config/theme_extras.php` alongside your other config files and set
+`$METERN_URL` to its URL; a link to it appears in the nav bar. Leave the
+file out (or `$METERN_URL = ''`) to skip it entirely - the theme works the
+same either way, this is purely cosmetic. Kept out of
+`config/config_main.php` on purpose: it's not part of 123solar's own
+config schema, so it can never collide with a future upstream key, and the
+admin panel's config editor cannot touch or wipe it.
+
+## Notes for anyone adapting this theme
+
+- The `@import` lines **must stay the first rule** in `css/style.css`
+  (only `@charset` may precede an `@import`), and deliberately load
+  Bootstrap/Font Awesome from there rather than from `head.php`:
+  `globalheader.php` links this stylesheet *before* including
+  `styles/yourheader.php`, so anything a site owner adds to
+  `yourheader.php` would otherwise win specificity ties against Bootstrap's
+  reset. Importing it in the CSS file instead means the cascade order is
+  decided in one place, not split across two files with different owners.
+- The light/dark switch defaults to light on first visit rather than
+  reading `prefers-color-scheme`, on purpose: a monitoring dashboard is as
+  often read on a bright screen outdoors as on a phone at night, so the
+  choice is left to an explicit, remembered click.
+
+## License
+
+Same license as the parent project (GNU GPLv3).

--- a/styles/meridiana/css/style.css
+++ b/styles/meridiana/css/style.css
@@ -1,0 +1,416 @@
+/**
+ * styles/meridiana/css/style.css
+ *
+ * "Meridiana" theme - 123solar side (see the meterN repo for the sibling
+ * implementation and the shared design rationale). A responsive,
+ * light/dark alternative to the default style, built on Bootstrap 5 and
+ * Font Awesome. Selected via [data-theme] on <body> (see header.php);
+ * page markup is still whatever 123solar generates, everything here is
+ * modernized via CSS alone - no engine file is touched by this theme.
+ *
+ * The @import below (must stay first, only @charset may precede an
+ * @import) is deliberate: globalheader.php (untouched upstream file)
+ * links this stylesheet BEFORE including styles/yourheader.php, so
+ * anything linked from yourheader.php would load AFTER this file and win
+ * specificity ties against it. Importing Bootstrap/Font Awesome here
+ * instead guarantees they load first in the cascade. Confirmed live:
+ * without this, Bootstrap's reboot.css was overriding the plain-table and
+ * link styling on index.php's per-inverter power list.
+ *
+ * See README.md in this directory for install/usage.
+ */
+
+@import url("https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css");
+
+:root,
+[data-theme="light"] {
+  --bg: #f2f5f9;
+  --surface: #ffffff;
+  --surface-alt: #f7f9fc;
+  --border: #e3e8ef;
+  --text: #161b26;
+  --text-muted: #667085;
+  --primary: #f59e0b;
+  --primary-ink: #7a4a04;
+  --primary-contrast: #1a1300;
+  --accent-1: #16a34a;
+  --accent-2: #2563eb;
+  --accent-3: #0891b2;
+  --accent-4: #7c3aed;
+  --accent-5: #ea580c;
+  --shadow: 0 1px 2px rgba(16, 24, 40, .06), 0 6px 20px rgba(16, 24, 40, .07);
+  --radius: 14px;
+  --nav-bg: #101827;
+  --nav-text: #e7ebf3;
+  --nav-text-muted: #93a0b8;
+  --nav-active: #f8b83c;
+  --nav-border: rgba(255, 255, 255, .08);
+}
+
+[data-theme="dark"] {
+  --bg: #0a0f1a;
+  --surface: #121a29;
+  --surface-alt: #172136;
+  --border: #253048;
+  --text: #e7ebf3;
+  --text-muted: #94a1b8;
+  --primary: #fbbf24;
+  --primary-ink: #2a1c00;
+  --primary-contrast: #1a1300;
+  --accent-1: #34d399;
+  --accent-2: #60a5fa;
+  --accent-3: #22d3ee;
+  --accent-4: #a78bfa;
+  --accent-5: #fb923c;
+  --shadow: 0 1px 2px rgba(0, 0, 0, .5), 0 10px 28px rgba(0, 0, 0, .55);
+  --nav-bg: #070b14;
+  --nav-text: #e7ebf3;
+  --nav-text-muted: #7c8aa5;
+  --nav-active: #fbbf24;
+  --nav-border: rgba(255, 255, 255, .06);
+}
+
+* { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Open Sans", Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+  transition: background-color .15s ease, color .15s ease;
+}
+
+a { color: var(--accent-2); text-decoration: none; }
+a:hover { text-decoration: underline; }
+img { max-width: 100%; }
+
+/* ---------- Header / navbar ---------- */
+
+.meridiana-header {
+  background: var(--nav-bg);
+  border-bottom: 1px solid var(--nav-border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.meridiana-header-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  min-height: 64px;
+  flex-wrap: wrap;
+}
+
+.meridiana-brand {
+  display: flex;
+  align-items: center;
+  gap: .65rem;
+  color: var(--nav-text) !important;
+  text-decoration: none !important;
+  margin-right: auto;
+}
+
+.meridiana-brand-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--primary), var(--accent-5));
+  color: var(--primary-contrast);
+  font-size: 1.1rem;
+}
+
+.meridiana-brand-text { display: flex; flex-direction: column; line-height: 1.15; }
+.meridiana-brand-text strong { font-size: 1.05rem; font-weight: 700; }
+.meridiana-brand-text small { color: var(--nav-text-muted); font-size: .72rem; }
+
+.meridiana-nav {
+  display: flex;
+  align-items: center;
+  gap: .25rem;
+  flex-wrap: wrap;
+}
+
+.meridiana-nav a {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  color: var(--nav-text-muted) !important;
+  text-decoration: none !important;
+  padding: .5rem .75rem;
+  border-radius: 8px;
+  font-size: .88rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.meridiana-nav a:hover { color: var(--nav-text) !important; background: rgba(255, 255, 255, .06); }
+.meridiana-nav a.active { color: var(--nav-active) !important; background: rgba(248, 184, 60, .12); }
+.meridiana-nav a.meridiana-nav-admin { opacity: .7; font-weight: 500; }
+.meridiana-nav a.meridiana-nav-metern { opacity: .9; }
+
+/* Inverter picker: replaces one nav link per inverter (which does not
+   scale past 3-4 units) with a single compact dropdown, "Tutti" (all,
+   the aggregate view) plus one entry per inverter with its real name -
+   more informative than a generic "Conv. N" and consistent with the
+   names already used in the per-inverter power list. */
+
+.meridiana-invt-select {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+  padding: .5rem .75rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, .06);
+  color: var(--nav-text-muted);
+  font-size: .88rem;
+}
+
+.meridiana-invt-select select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--nav-text);
+  font: inherit;
+  font-weight: 600;
+  padding-right: 1.1rem;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.meridiana-invt-select select:focus-visible { outline: 2px solid var(--nav-active); outline-offset: 2px; }
+
+/* The dropdown popup is rendered by the OS/browser, outside our dark
+   navbar: force a readable dark-on-light pair for the options so it
+   never inherits our light-on-dark colors and ends up unreadable. */
+.meridiana-invt-select select option {
+  color: #161b26;
+  background: #ffffff;
+}
+
+.meridiana-invt-select-arrow {
+  position: absolute;
+  right: .55rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: .65rem;
+  pointer-events: none;
+  color: var(--nav-text-muted);
+}
+
+.meridiana-theme-toggle,
+.meridiana-nav-toggle {
+  background: rgba(255, 255, 255, .06);
+  border: 1px solid var(--nav-border);
+  color: var(--nav-text);
+  width: 38px;
+  height: 38px;
+  border-radius: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: .95rem;
+}
+
+.meridiana-theme-toggle:hover, .meridiana-nav-toggle:hover { background: rgba(255, 255, 255, .12); }
+
+.meridiana-theme-toggle .fa-moon { display: none; }
+[data-theme="dark"] .meridiana-theme-toggle .fa-sun { display: none; }
+[data-theme="dark"] .meridiana-theme-toggle .fa-moon { display: inline; }
+
+.meridiana-nav-toggle { display: none; }
+
+/* ---------- Main content ---------- */
+
+.meridiana-main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 3rem;
+}
+
+/* ---------- Generic tables (detailed/production/comparison/info) ---------- */
+
+.meridiana-main table {
+  border-collapse: collapse;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.meridiana-main table[border] { border: 1px solid var(--border) !important; }
+
+.meridiana-main table[border] td,
+.meridiana-main table[border] th {
+  border: 1px solid var(--border) !important;
+  padding: .5rem .65rem;
+}
+
+.meridiana-main table[bgcolor] { background: var(--surface) !important; }
+.meridiana-main tr[bgcolor] { background: var(--surface-alt) !important; }
+.meridiana-main table tr:hover td { background: var(--surface-alt); }
+
+/* ---------- index.php layout: a single sidebar (gauge + per-inverter
+   power list) beside ALL THREE charts (today, yesterday, last 30 days)
+   stacked in one column - not the two-<table>s-in-a-row markup index.php
+   actually emits (row 1: today + gauge; row 2: yesterday + last-N-days
+   side by side). With many inverters the sidebar list can grow taller
+   than a single 420px chart; a shared flex row would then force the
+   yesterday/last-N-days row to wait for the sidebar to finish, leaving a
+   gap under the shorter chart. Grid columns don't share that constraint:
+   the chart stack flows independently of the sidebar's height. Both of
+   index.php's <table width="100%"> wrappers are "unwrapped" via
+   display:contents so their <td>s become direct grid items of one grid -
+   zero changes to index.php. */
+
+.page-index .meridiana-main {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  align-items: start;
+  gap: 1.25rem;
+  /* The charts are the main reason to be on this page: give them the
+     full viewport width instead of the 1400px cap used elsewhere, where
+     it helps readability of tables/forms more than it would help here. */
+  max-width: none;
+}
+
+.page-index .meridiana-main > table[width="100%"],
+.page-index .meridiana-main > table[width="100%"] > tbody,
+.page-index .meridiana-main > table[width="100%"] > tbody > tr {
+  display: contents;
+}
+
+.page-index .meridiana-main td[width="20%"] {
+  display: block;
+  /* index.php's own width="20%"/"80%"/"50%" HTML attributes still apply
+     as a low-priority presentational width - but inside a grid, a
+     percentage resolves against the GRID AREA, not the page, so
+     "20%" of a 300px column collapsed the sidebar (and gauge) to ~60px.
+     display:block alone doesn't cancel that; only an explicit width
+     does. Found by comparing against the meterN theme, where the
+     equivalent columns use flexbox with an explicit flex-basis, which
+     wins over the width attribute for a different reason and never hit
+     this bug. */
+  width: 100%;
+  grid-column: 1;
+  grid-row: 1 / span 3; /* spans today + yesterday + last-N-days */
+}
+
+.page-index .meridiana-main td[width="80%"],
+.page-index .meridiana-main td[width="50%"] {
+  display: block;
+  width: 100%;
+  grid-column: 2;
+  min-width: 0; /* let Highcharts shrink instead of overflowing */
+}
+
+/* ---------- Footer ---------- */
+
+.meridiana-footer {
+  border-top: 1px solid var(--border);
+  padding: 1.25rem;
+  margin-top: 1rem;
+}
+
+.meridiana-footer-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: .5rem;
+  color: var(--text-muted);
+  font-size: .8rem;
+}
+
+.meridiana-footer-inner a { color: var(--text-muted); }
+
+/* ---------- Legacy menu (m.php / links.php) and loading dots ---------- */
+
+.lds-ellipsis div { background: var(--primary) !important; }
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 860px) {
+  .meridiana-nav-toggle { display: inline-flex; order: 2; }
+  .meridiana-theme-toggle { order: 3; }
+
+  .meridiana-nav {
+    display: none;
+    order: 4;
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding-top: .5rem;
+    border-top: 1px solid var(--nav-border);
+    margin-top: .5rem;
+  }
+
+  .meridiana-nav.open { display: flex; }
+  .meridiana-nav a { padding: .7rem .5rem; border-radius: 6px; }
+
+  .meridiana-main { padding: 1rem .75rem 2rem; }
+
+  /* Single column: sidebar first (order:1), then the three charts in
+     their natural today/yesterday/last-N-days order. */
+  .page-index .meridiana-main {
+    grid-template-columns: 1fr;
+  }
+  .page-index .meridiana-main td[width="20%"] {
+    grid-column: 1;
+    grid-row: auto;
+    order: 1;
+  }
+  .page-index .meridiana-main td[width="80%"] {
+    grid-column: 1;
+    order: 2;
+  }
+  .page-index .meridiana-main td[width="50%"] {
+    grid-column: 1;
+    order: 3;
+  }
+
+  /* Raw data tables (detailed/production/comparison/info): horizontal
+     scroll instead of squeezing the columns. Excludes index.php's own
+     layout tables (chart/gauge scaffolding): those are already flattened
+     into grid items via display:contents above, a rule specific enough
+     to outrank this one regardless of media query. */
+  .meridiana-main table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    white-space: nowrap;
+  }
+  .page-index .meridiana-main table[width="100%"] {
+    overflow-x: visible;
+    white-space: normal;
+  }
+}
+
+@media (max-width: 480px) {
+  .meridiana-brand-text small { display: none; }
+}
+
+/* dashboard.php (per-inverter drill-down) positions some elements with
+   fixed-pixel Highcharts renderer text/gauges: same known limitation as
+   the meterN dashboard - scrollable on narrow screens instead of broken,
+   full reflow is out of scope for a theme. */
+.page-dashboard .meridiana-main {
+  overflow-x: auto;
+}

--- a/styles/meridiana/footer.php
+++ b/styles/meridiana/footer.php
@@ -1,0 +1,76 @@
+<!-- #EndEditable -->
+</main>
+
+<footer class="meridiana-footer">
+  <div class="meridiana-footer-inner">
+    <a href="https://github.com/jeanmarc77/123solar" target="_blank" rel="noopener">Powered by 123Solar</a>
+  </div>
+</footer>
+
+<script>
+(function () {
+  var themeBtn = document.getElementById('meridianaThemeToggle');
+  if (themeBtn) {
+    themeBtn.addEventListener('click', function () {
+      var body = document.body;
+      var cur = body.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      body.setAttribute('data-theme', next);
+      document.cookie = 'color_scheme=' + next + '; path=/; max-age=31536000; samesite=lax';
+      if (window.Highcharts) {
+        /* Mirrors the palette set once at load time in header.php's
+         * Highcharts.setOptions() call. That call only runs on page
+         * load, so toggling afterwards needs to re-apply every themed
+         * property here too - grid lines alone (the original version of
+         * this handler) left title/legend/axis-label/tooltip text at
+         * the OLD theme's color, invisible against the new background. */
+        var dark = next === 'dark';
+        var textColor = dark ? '#e7ebf3' : '#161b26';
+        var mutedColor = dark ? '#94a1b8' : '#667085';
+        var gridColor = dark ? '#253048' : '#e3e8ef';
+        var tooltipBg = dark ? '#121a29' : '#ffffff';
+        var themeOpts = {
+          title: { style: { color: textColor } },
+          subtitle: { style: { color: mutedColor } },
+          xAxis: {
+            gridLineColor: gridColor, lineColor: gridColor, tickColor: gridColor,
+            labels: { style: { color: mutedColor } }
+          },
+          yAxis: {
+            gridLineColor: gridColor,
+            labels: { style: { color: mutedColor } },
+            title: { style: { color: mutedColor } }
+          },
+          legend: { itemStyle: { color: textColor } },
+          tooltip: { backgroundColor: tooltipBg, borderColor: gridColor, style: { color: textColor } }
+        };
+        Highcharts.setOptions(themeOpts);
+        Highcharts.charts.forEach(function (chart) {
+          if (!chart) { return; }
+          chart.update(themeOpts, false);
+          chart.redraw();
+        });
+      }
+    });
+  }
+
+  var navBtn = document.getElementById('meridianaNavToggle');
+  var nav = document.getElementById('meridianaNav');
+  if (navBtn && nav) {
+    navBtn.addEventListener('click', function () {
+      var expanded = navBtn.getAttribute('aria-expanded') === 'true';
+      navBtn.setAttribute('aria-expanded', String(!expanded));
+      nav.classList.toggle('open');
+    });
+  }
+
+  var invtSelect = document.getElementById('meridianaInvtSelect');
+  if (invtSelect) {
+    invtSelect.addEventListener('change', function () {
+      if (this.value) { window.location.href = this.value; }
+    });
+  }
+})();
+</script>
+</body>
+</html>

--- a/styles/meridiana/head.php
+++ b/styles/meridiana/head.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * styles/meridiana/head.php
+ *
+ * Per-style <head> additions for the "Meridiana" theme, included by
+ * styles/globalheader.php right before the theme's own stylesheet.
+ *
+ * Holds only the viewport meta tag, without which no amount of CSS makes
+ * the pages usable on a phone: 123solar ships no viewport tag of its own,
+ * so a mobile browser lays the page out at its default virtual width and
+ * scales the result down.
+ *
+ * Deliberately kept out of styles/yourheader.php (the untouched, official
+ * loose-file extension point): an admin.php-triggered update only
+ * preserves custom style *directories*, not loose files directly under
+ * styles/, so anything placed in yourheader.php is silently lost on the
+ * next update. Everything a theme needs belongs inside the theme's own
+ * directory instead.
+ *
+ * Bootstrap and Font Awesome are deliberately NOT linked here even though
+ * this file is included before the theme stylesheet: they are @imported as
+ * the first rule of css/style.css instead. Both orders would work today,
+ * but keeping every external dependency in one place means the cascade is
+ * decided by a single file, the one that also has to live with it.
+ *
+ * @package default
+ */
+?>
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<?php
+// vim: set ts=4 sw=4 noet:

--- a/styles/meridiana/header.php
+++ b/styles/meridiana/header.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * styles/meridiana/header.php
+ *
+ * Header for the "Meridiana" theme (123solar side - see the meterN tree
+ * for the sibling implementation and the full rationale: responsive
+ * navbar, light/dark cookie, Highcharts theming, official extension point
+ * per styles/default/Explanation.txt). $TITLE, $SUBTITLE, $lgM*, $NUMINV
+ * are already populated by styles/globalheader.php (config_main.php +
+ * language file), which includes this file right after closing </head>.
+ *
+ */
+
+// Always opens light unless the visitor has explicitly toggled to dark
+// (cookie set by footer.php's toggle button): no system-preference
+// auto-detection here, on purpose - a monitoring dashboard is as often
+// read on a bright screen outdoors as on a phone at night, so the choice
+// is left to an explicit, remembered click rather than guessed from the
+// OS, which may not reflect the room the dashboard is actually read in.
+$meridianaTheme = (isset($_COOKIE['color_scheme']) && $_COOKIE['color_scheme'] === 'dark') ? 'dark' : 'light';
+$meridianaPage = basename(parse_url($_SERVER['PHP_SELF'], PHP_URL_PATH), '.php');
+if ($meridianaPage === '') {
+    $meridianaPage = 'index';
+}
+$meridianaSelInvt = isset($_GET['selectinvt']) ? (int) $_GET['selectinvt'] : 0;
+
+// Optional cross-link to meterN, if installed for this plant. Kept in its
+// own file (not config_main.php) so it can never collide with 123solar's
+// own config schema - see config/theme_extras.php for the rationale.
+$meridianaMeternUrl = '';
+$meridianaThemeConfigFile = __DIR__ . '/../../config/theme_extras.php';
+if (is_file($meridianaThemeConfigFile)) {
+    include $meridianaThemeConfigFile;
+    if (!empty($METERN_URL)) {
+        $meridianaMeternUrl = $METERN_URL;
+    }
+}
+?>
+<body data-theme="<?php echo htmlspecialchars($meridianaTheme, ENT_QUOTES); ?>" class="page-<?php echo htmlspecialchars($meridianaPage, ENT_QUOTES); ?>">
+
+<header class="meridiana-header">
+  <div class="meridiana-header-inner">
+    <a class="meridiana-brand" href="index.php">
+      <span class="meridiana-brand-icon"><i class="fa-solid fa-solar-panel"></i></span>
+      <span class="meridiana-brand-text">
+        <strong><?php echo htmlspecialchars($TITLE, ENT_QUOTES); ?></strong>
+        <small><?php echo htmlspecialchars(strip_tags($SUBTITLE), ENT_QUOTES); ?></small>
+      </span>
+    </a>
+
+    <button type="button" class="meridiana-theme-toggle" id="meridianaThemeToggle" aria-label="Light / dark switch" title="Light / dark">
+      <i class="fa-solid fa-sun"></i><i class="fa-solid fa-moon"></i>
+    </button>
+    <button type="button" class="meridiana-nav-toggle" id="meridianaNavToggle" aria-label="Menu" aria-expanded="false" aria-controls="meridianaNav">
+      <i class="fa-solid fa-bars"></i>
+    </button>
+
+    <nav class="meridiana-nav" id="meridianaNav">
+      <a href="index.php" class="<?php echo ($meridianaPage === 'index' && $meridianaSelInvt === 0) ? 'active' : ''; ?>"><i class="fa-solid fa-chart-line"></i><?php echo $lgMINDEX; ?></a>
+<?php if (!empty($NUMINV) && $NUMINV > 1): ?>
+      <div class="meridiana-invt-select">
+        <i class="fa-solid fa-solar-panel" aria-hidden="true"></i>
+        <select id="meridianaInvtSelect" aria-label="<?php echo htmlspecialchars($lgMINDEX, ENT_QUOTES); ?>">
+          <option value="index.php"<?php echo $meridianaSelInvt === 0 ? ' selected' : ''; ?>>Tutti</option>
+<?php for ($bi = 1; $bi <= $NUMINV; $bi++): ?>
+          <option value="index.php?selectinvt=<?php echo $bi; ?>"<?php echo $meridianaSelInvt === $bi ? ' selected' : ''; ?>><?php echo htmlspecialchars(${'INVNAME' . $bi}, ENT_QUOTES); ?></option>
+<?php endfor; ?>
+        </select>
+        <i class="fa-solid fa-chevron-down meridiana-invt-select-arrow" aria-hidden="true"></i>
+      </div>
+<?php endif; ?>
+      <a href="production.php" class="<?php echo $meridianaPage === 'production' ? 'active' : ''; ?>"><i class="fa-solid fa-bolt"></i><?php echo $lgMPRODUCTION; ?></a>
+      <a href="detailed.php" class="<?php echo $meridianaPage === 'detailed' ? 'active' : ''; ?>"><i class="fa-solid fa-table-list"></i><?php echo $lgMDETAILED; ?></a>
+      <a href="comparison.php" class="<?php echo $meridianaPage === 'comparison' ? 'active' : ''; ?>"><i class="fa-solid fa-code-compare"></i><?php echo $lgMCOMPARISON; ?></a>
+      <a href="info.php" class="<?php echo $meridianaPage === 'info' ? 'active' : ''; ?>"><i class="fa-solid fa-circle-info"></i><?php echo $lgMINFO; ?></a>
+<?php if ($meridianaMeternUrl !== ''): ?>
+      <a href="<?php echo htmlspecialchars($meridianaMeternUrl, ENT_QUOTES); ?>" class="meridiana-nav-metern" target="_blank" rel="noopener"><i class="fa-solid fa-house-chimney-window"></i>meterN</a>
+<?php endif; ?>
+      <a href="admin/" class="meridiana-nav-admin"><i class="fa-solid fa-gear"></i>admin</a>
+    </nav>
+  </div>
+</header>
+
+<script>
+/* Visual theme for Highcharts. Must run before the page's own script
+ * (index.php etc.), which also calls Highcharts.setOptions() but only for
+ * locale/decimal formatting: since it's a deep merge, these settings
+ * survive (same finding as the meterN theme - see TODO.md point 9). */
+if (window.Highcharts) {
+  var meridianaDark = document.body.getAttribute('data-theme') === 'dark';
+  Highcharts.setOptions({
+    colors: ['#f59e0b', '#2563eb', '#16a34a', '#7c3aed', '#0891b2', '#ea580c'],
+    chart: {
+      backgroundColor: 'transparent',
+      style: { fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif' }
+    },
+    title: { style: { color: meridianaDark ? '#e7ebf3' : '#161b26', fontWeight: '700' } },
+    subtitle: { style: { color: meridianaDark ? '#94a1b8' : '#667085' } },
+    xAxis: {
+      gridLineColor: meridianaDark ? '#253048' : '#e3e8ef',
+      lineColor: meridianaDark ? '#253048' : '#e3e8ef',
+      tickColor: meridianaDark ? '#253048' : '#e3e8ef',
+      labels: { style: { color: meridianaDark ? '#94a1b8' : '#667085' } }
+    },
+    yAxis: {
+      gridLineColor: meridianaDark ? '#253048' : '#e3e8ef',
+      labels: { style: { color: meridianaDark ? '#94a1b8' : '#667085' } },
+      title: { style: { color: meridianaDark ? '#94a1b8' : '#667085' } }
+    },
+    legend: { itemStyle: { color: meridianaDark ? '#e7ebf3' : '#161b26' } },
+    tooltip: {
+      backgroundColor: meridianaDark ? '#121a29' : '#ffffff',
+      borderColor: meridianaDark ? '#253048' : '#e3e8ef',
+      style: { color: meridianaDark ? '#e7ebf3' : '#161b26' }
+    }
+  });
+}
+</script>
+
+<main class="meridiana-main">
+<!-- #BeginEditable "mainbox" -->


### PR DESCRIPTION
Addresses several of the wiki's own "Ideas" at once (HTML5/CSS cleanup, Bootstrap, Font Awesome), by contributing a complete drop-in theme instead of reworking the default one - existing installations keep using the default style unless they opt in, and nothing in the engine is touched.

What it adds: a responsive top navbar (phone through desktop) in place of the legacy fixed-width table layout, a light/dark switch remembered in a cookie with a matching Highcharts palette on both load and toggle, a per-inverter quick-select in the nav when $NUMINV > 1, and Font Awesome icons throughout. Bootstrap 5 and Font Awesome are loaded via CDN @import in the theme's own stylesheet - no build step, no bundled copy of either library to keep updated, and no engine file is modified: install is copy the directory, set $STYLE, done.

Also adds config/theme_extras.php, an optional file read directly by the theme (not part of config_main.php's own schema, so it can't collide with a future upstream key or be touched by the admin panel's config editor): if set, it links to a companion meterN install on the same site. Absent or empty, the theme works the same either way.

Depends on the per-style <head> hook from 12b8812 (this repo) for the viewport meta tag - noted in the theme's own README, along with the handful of small decisions that aren't obvious from the code alone.

Sibling of the meterN implementation (same repo owner, same design and CSS variables), proposed separately since they are two different engines with two different config schemas.

Verified with a local preview against the example config this repo ships (config/config_main.php, $STYLE=meridiana): theme stylesheet and viewport tag both load, Bootstrap/Font Awesome resolve from the CDN imports, no PHP warnings.